### PR TITLE
Ssl version

### DIFF
--- a/lib/ruby-tls/ssl.rb
+++ b/lib/ruby-tls/ssl.rb
@@ -128,6 +128,8 @@ module RubyTls
         # Constructor
         attach_function :SSLv23_server_method, [], :pointer
         attach_function :SSLv23_client_method, [], :pointer
+        attach_function :TLSv1_server_method, [], :pointer
+        attach_function :TLSv1_client_method, [], :pointer
         attach_function :SSL_CTX_new, [:pointer], :ssl_ctx
 
         attach_function :SSL_CTX_ctrl, [:ssl_ctx, :int, :ulong, :pointer], :long
@@ -179,9 +181,15 @@ module RubyTls
         attach_function :SSL_CTX_set_session_id_context, [:ssl_ctx, :string, :buffer_length], :int
         attach_function :SSL_load_client_CA_file, [:string], :pointer
         attach_function :SSL_CTX_set_client_CA_list, [:ssl_ctx, :pointer], :void
+        attach_function :SSL_CTX_load_verify_locations, [:ssl_ctx, :pointer], :int, :blocking => true
 
         # OpenSSL before 1.0.2 do not have these methods
         begin
+        		attach_function :TLSv1_1_server_method, [], :pointer
+        		attach_function :TLSv1_1_client_method, [], :pointer
+        		attach_function :TLSv1_2_server_method, [], :pointer
+        		attach_function :TLSv1_2_client_method, [], :pointer
+
             attach_function :SSL_CTX_set_alpn_protos, [:ssl_ctx, :string, :uint], :int
 
             OPENSSL_NPN_UNSUPPORTED = 0

--- a/spec/comms_spec.rb
+++ b/spec/comms_spec.rb
@@ -4,6 +4,12 @@ describe RubyTls do
 
     describe RubyTls::SSL::Box do
 
+				it "fails when passed as unsupported TLS version" do
+					expect {
+						RubyTls::SSL::Box.new(false, nil, version: :TLSv1_3)
+					}.to raise_error(/is unsupported/)
+				end
+
         it "should be able to send and receive encrypted comms" do
             @server_data = []
             @client_data = []


### PR DESCRIPTION
* Adds method `RubyTls::SSL.version`, which returns the version of the linked library.
* Adds a new option to the initializers (`:version`) to determine the SSL/TLS version to use (accepts the same values as in ruby's `openssl`).
* Show the library version in the error message when initializing with an unsupported TLS version. 